### PR TITLE
feat: make configurable per repo

### DIFF
--- a/index.js
+++ b/index.js
@@ -12,11 +12,11 @@ module.exports = (robot) => {
   robot.on(
     ["issues.opened", "issues.edited", "issues.unassigned"],
     async (context) => {
-      const config = await context.config("config.yml", {
-        addAssignees: true,
+      const config = await context.config("always-assign.yml", {
+        enabled: true,
       });
 
-      if (!config.addAssignees) {
+      if (!config.enabled) {
         return;
       }
 

--- a/index.js
+++ b/index.js
@@ -1,17 +1,28 @@
 "use strict";
 
 function assignSender(context) {
-  context.github.issues.addAssigneesToIssue(context.issue({
-    assignees: [context.payload.sender.login]
-  }));
+  context.github.issues.addAssigneesToIssue(
+    context.issue({
+      assignees: [context.payload.sender.login],
+    })
+  );
 }
 
 module.exports = (robot) => {
+  robot.on(
+    ["issues.opened", "issues.edited", "issues.unassigned"],
+    async (context) => {
+      const config = await context.config("config.yml", {
+        addAssignees: true,
+      });
 
-  robot.on(["issues.opened", "issues.edited", "issues.unassigned"], async context => {
-    if (context.payload.issue.assignees.length === 0) {
-      assignSender(context);
+      if (!config.addAssignees) {
+        return;
+      }
+
+      if (context.payload.issue.assignees.length === 0) {
+        assignSender(context);
+      }
     }
-  });
-
+  );
 };


### PR DESCRIPTION
Changes proposed in #2 

I'm using a default filename for the config atm: `config.yml`. Should (or can) this be configurable? @leomelzer @meaku 